### PR TITLE
Add Regexp tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Below are some very preliminary benchmarks on the 20 newsgroups dataset of 19924
 | estimator         | implementation                    | speed        |
 |-------------------|-----------------------------------|--------------|
 | CountVectorizer   | scikit-learn 0.20 (Python)        | 14 MB/s      |
-| CountVectorizer   | text-vectorize 0.1.0-alpha (Rust) | 40 MB/s      |
+| CountVectorizer   | text-vectorize 0.1.0-alpha (Rust) | 33 MB/s      |
 | HashingVectorizer | scikit-learn 0.20 (Python+Cython) | 18 MB/s      |
-| HashingVectorizer | text-vectorize 0.1.0-alpha (Rust) | 75 MB/s      |
+| HashingVectorizer | text-vectorize 0.1.0-alpha (Rust) | 68 MB/s      |
 
 see [benchmarks/README.md](./benchmarks/README.md) for more details.
 Note that these are not strictly equivalent, because

--- a/benchmarks/bench_scikit-learn.py
+++ b/benchmarks/bench_scikit-learn.py
@@ -3,7 +3,7 @@ from glob import glob
 
 import sklearn.feature_extraction.text as skt
 
-import text_vectorize
+import pytext_vectorize
 
 
 if __name__ == "__main__":
@@ -17,7 +17,7 @@ if __name__ == "__main__":
 
     t0 = time()
 
-    vect = text_vectorize.HashingVectorizer(norm=None)
+    vect = pytext_vectorize.HashingVectorizer(norm=None)
     vect.fit_transform(data)
 
     dt = time() - t0
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     )
 
     t0 = time()
-    vect = text_vectorize.CountVectorizer(lowercase=False)
+    vect = pytext_vectorize.CountVectorizer(lowercase=False)
     vect.fit_transform(data)
 
     dt = time() - t0

--- a/python/pytext_vectorize/tests/test_tokenize.py
+++ b/python/pytext_vectorize/tests/test_tokenize.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pytext_vectorize.tokenize import UnicodeSegmentTokenizer
+from pytext_vectorize.tokenize import RegexpTokenizer
 
 
 def test_unicode_segment_tokenize():
@@ -16,3 +17,9 @@ def test_unicode_segment_tokenize():
 
     with pytest.raises(TypeError):
         UnicodeSegmentTokenizer().tokenize(2)
+
+
+def test_regexp_tokenize():
+
+    tokenizer = RegexpTokenizer(pattern=r"\b\w\w+\b")
+    assert tokenizer.tokenize("Today, tomorrow") == ["Today", "tomorrow"]

--- a/python/pytext_vectorize/tokenize.py
+++ b/python/pytext_vectorize/tokenize.py
@@ -1,4 +1,5 @@
 from ._lib import UnicodeSegmentTokenizer
+from ._lib import RegexpTokenizer
 
 
-__all__ = ["UnicodeSegmentTokenizer"]
+__all__ = ["UnicodeSegmentTokenizer", "RegexpTokenizer"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -121,7 +121,7 @@ impl _CountVectorizerWrapper {
     }
 }
 
-/// Tokenize with Unicode Segmentation
+/// Unicode Segmentation tokenizer
 ///
 /// This implementation is a thin wrapper around the
 /// `unicode-segmentation` crate
@@ -131,7 +131,7 @@ impl _CountVectorizerWrapper {
 /// * [Unicode® Standard Annex #29](http://www.unicode.org/reports/tr29/)
 #[pyclass]
 pub struct UnicodeSegmentTokenizer {
-    word_bounds: bool,
+    pub word_bounds: bool,
 }
 
 #[pymethods]
@@ -153,9 +153,40 @@ impl UnicodeSegmentTokenizer {
     /// ## Returns
     ///  - tokens : List<str>
     fn tokenize(&self, py: Python, x: String) -> PyResult<(Vec<String>)> {
-        let tokenizer = text_vectorize::tokenize::UnicodeSegmentTokenizer {
-            word_bounds: self.word_bounds,
-        };
+        let tokenizer = text_vectorize::tokenize::UnicodeSegmentTokenizer::new(self.word_bounds);
+
+        let x = x.to_string();
+
+        let res = tokenizer.tokenize(&x);
+        let res = res.iter().map(|s| s.to_string()).collect();
+        Ok((res))
+    }
+}
+
+/// Tokenize a document using regular expressions
+#[pyclass]
+pub struct RegexpTokenizer {
+    pub pattern: String,
+}
+
+#[pymethods]
+impl RegexpTokenizer {
+    #[new]
+    //    #[args(pattern = "\\b\\w\\w+\\b".to_string())]
+    fn __new__(obj: &PyRawObject, pattern: String) -> PyResult<()> {
+        obj.init(|_token| RegexpTokenizer { pattern: pattern })
+    }
+
+    /// Tokenize a string
+    ///
+    /// ## Parameters
+    ///  - x : bool
+    ///    the string to tokenize
+    ///
+    /// ## Returns
+    ///  - tokens : List<str>
+    fn tokenize(&self, py: Python, x: String) -> PyResult<(Vec<String>)> {
+        let tokenizer = text_vectorize::tokenize::RegexpTokenizer::new(self.pattern.to_owned());
 
         let x = x.to_string();
 
@@ -170,6 +201,7 @@ fn _lib(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<_HashingVectorizerWrapper>()?;
     m.add_class::<_CountVectorizerWrapper>()?;
     m.add_class::<UnicodeSegmentTokenizer>()?;
+    m.add_class::<RegexpTokenizer>()?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,14 +52,6 @@ mod tests;
 mod math;
 pub mod tokenize;
 
-/// Analyze tokens
-///
-/// Given a list of tokens (words or character groups) in a document,  
-/// this corresponding word or character n-grams.
-pub fn analyze<'a>(tokens: impl Iterator<Item = &'a str>) -> impl Iterator<Item = &'a str> {
-    tokens
-}
-
 /// Sort features by name
 ///
 /// Returns a reordered matrix and modifies the vocabulary in place
@@ -168,12 +160,12 @@ impl CountVectorizer {
 
             let tokens = tokenizer.tokenize(&document);
 
-            let n_grams = analyze(tokens.iter());
             indices_local.clear();
-            for token in n_grams {
+            for token in tokens.iter() {
                 let vocabulary_size = vocabulary.len() as i32;
+                // TODO: don't convert to Sting here
                 let token_id = vocabulary
-                    .entry(token.to_owned())
+                    .entry(token.to_string())
                     .or_insert(vocabulary_size);
                 indices_local.push(*token_id as u32);
             }
@@ -249,9 +241,8 @@ impl HashingVectorizer {
             let document = document.to_ascii_lowercase();
 
             let tokens = tokenizer.tokenize(&document);
-            let n_grams = analyze(tokens.iter());
             indices_local.clear();
-            for token in n_grams {
+            for token in tokens.iter() {
                 let hash = fasthash::murmur3::hash32(&token);
                 let hash = hash % self.n_features;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,9 +151,7 @@ impl CountVectorizer {
         let mut nnz: usize = 0;
         let mut indices_local = Vec::new();
 
-        let tokenizer = tokenize::RegexpTokenizer {
-            pattern: TOKEN_PATTERN_DEFAULT.to_string(),
-        };
+        let tokenizer = tokenize::RegexpTokenizer::new(TOKEN_PATTERN_DEFAULT.to_string());
 
         for (_document_id, document) in X.iter().enumerate() {
             let document = document.to_ascii_lowercase();
@@ -228,9 +226,7 @@ impl HashingVectorizer {
         let mut indices_local = Vec::new();
         let mut nnz: usize = 0;
 
-        let tokenizer = tokenize::RegexpTokenizer {
-            pattern: TOKEN_PATTERN_DEFAULT.to_string(),
-        };
+        let tokenizer = tokenize::RegexpTokenizer::new(TOKEN_PATTERN_DEFAULT.to_string());
 
         for (_document_id, document) in X.iter().enumerate() {
             // String.to_lowercase() is very slow

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -1,8 +1,10 @@
 extern crate unicode_segmentation;
+extern crate regex;
 
+use regex::Regex;
 use unicode_segmentation::UnicodeSegmentation;
 
-/// Tokenize with Unicode Segmentation
+/// Unicode Segmentation tokenizer
 ///
 /// This implementation is a thin wrapper around the
 /// `unicode-segmentation` crate
@@ -27,9 +29,29 @@ impl UnicodeSegmentTokenizer {
     }
 }
 
+const TOKEN_PATTERN_DEFAULT: &str = r"\b\w\w+\b";
+
+/// Regular expression tokenizer
+///
+#[derive(Debug)]
+pub struct RegexpTokenizer {
+    pub pattern: String,
+}
+
+impl RegexpTokenizer {
+    /// Tokenize a string
+    pub fn tokenize<'a>(&self, text: &'a str) -> Vec<&'a str> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(TOKEN_PATTERN_DEFAULT).unwrap();
+        }
+
+        RE.find_iter(text).map(|m| m.as_str()).collect() //.collect::Vec<&str>
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::tokenize::UnicodeSegmentTokenizer;
+    use crate::tokenize::{UnicodeSegmentTokenizer,RegexpTokenizer};
 
     #[test]
     fn test_unicode_tokenizer() {
@@ -48,6 +70,16 @@ mod tests {
             "The", "quick", "(", "\"", "brown", "\"", ")", "fox", "can't", "jump", "32.3", "feet",
             ",", "right", "?",
         ];
+        assert_eq!(tokens, b);
+    }
+
+    #[test]
+    fn test_regexp_tokenizer() {
+        let s = "fox can't jump 32.3 feet, right?";
+
+        let tokenizer = RegexpTokenizer { pattern: r"\b\w\w+\b".to_string() };
+        let tokens = tokenizer.tokenize(s);
+        let b: &[_] = &["fox", "can", "jump", "32", "feet", "right"];
         assert_eq!(tokens, b);
     }
 }

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -1,5 +1,5 @@
-extern crate unicode_segmentation;
 extern crate regex;
+extern crate unicode_segmentation;
 
 use regex::Regex;
 use unicode_segmentation::UnicodeSegmentation;
@@ -51,7 +51,7 @@ impl RegexpTokenizer {
 
 #[cfg(test)]
 mod tests {
-    use crate::tokenize::{UnicodeSegmentTokenizer,RegexpTokenizer};
+    use crate::tokenize::{RegexpTokenizer, UnicodeSegmentTokenizer};
 
     #[test]
     fn test_unicode_tokenizer() {
@@ -77,7 +77,9 @@ mod tests {
     fn test_regexp_tokenizer() {
         let s = "fox can't jump 32.3 feet, right?";
 
-        let tokenizer = RegexpTokenizer { pattern: r"\b\w\w+\b".to_string() };
+        let tokenizer = RegexpTokenizer {
+            pattern: r"\b\w\w+\b".to_string(),
+        };
         let tokens = tokenizer.tokenize(s);
         let b: &[_] = &["fox", "can", "jump", "32", "feet", "right"];
         assert_eq!(tokens, b);

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -18,6 +18,12 @@ pub struct UnicodeSegmentTokenizer {
 }
 
 impl UnicodeSegmentTokenizer {
+    /// Create a new instance
+    pub fn new(word_bounds: bool) -> UnicodeSegmentTokenizer {
+        UnicodeSegmentTokenizer {
+            word_bounds: word_bounds,
+        }
+    }
     /// Tokenize a string
     pub fn tokenize<'a>(&self, text: &'a str) -> Vec<&'a str> {
         if self.word_bounds {
@@ -29,23 +35,27 @@ impl UnicodeSegmentTokenizer {
     }
 }
 
-const TOKEN_PATTERN_DEFAULT: &str = r"\b\w\w+\b";
-
 /// Regular expression tokenizer
 ///
 #[derive(Debug)]
 pub struct RegexpTokenizer {
     pub pattern: String,
+    regexp: Regex,
 }
 
 impl RegexpTokenizer {
+    /// Create a new instance
+    pub fn new(pattern: String) -> RegexpTokenizer {
+        let regexp = Regex::new(&pattern).unwrap();
+
+        RegexpTokenizer {
+            pattern: pattern,
+            regexp: regexp,
+        }
+    }
     /// Tokenize a string
     pub fn tokenize<'a>(&self, text: &'a str) -> Vec<&'a str> {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(TOKEN_PATTERN_DEFAULT).unwrap();
-        }
-
-        RE.find_iter(text).map(|m| m.as_str()).collect() //.collect::Vec<&str>
+        self.regexp.find_iter(text).map(|m| m.as_str()).collect() //.collect::Vec<&str>
     }
 }
 
@@ -77,9 +87,7 @@ mod tests {
     fn test_regexp_tokenizer() {
         let s = "fox can't jump 32.3 feet, right?";
 
-        let tokenizer = RegexpTokenizer {
-            pattern: r"\b\w\w+\b".to_string(),
-        };
+        let tokenizer = RegexpTokenizer::new(r"\b\w\w+\b".to_string());
         let tokens = tokenizer.tokenize(s);
         let b: &[_] = &["fox", "can", "jump", "32", "feet", "right"];
         assert_eq!(tokens, b);


### PR DESCRIPTION
This adds a Regexp tokenizer, which is, for instance, the default tokenizer in scikit-learn.