### PR TITLE
Return iterator in tokenizers

### DIFF
--- a/benchmarks/bench_tokenizers.py
+++ b/benchmarks/bench_tokenizers.py
@@ -1,17 +1,20 @@
 from time import time
 from glob import glob
+from pathlib import Path
 import re
 
 from pytext_vectorize.tokenize import RegexpTokenizer
 from pytext_vectorize.tokenize import UnicodeSegmentTokenizer
 
+base_dir = Path(__file__).parent.parent.resolve()
 
 if __name__ == "__main__":
-    input_files = list(glob("./data/*/*"))
+    input_files = list(glob(str(base_dir / "data" / "*" / "*")))
     data = []
     for file_path in input_files:
         with open(file_path, "rt") as fh:
             data.append(fh.read())
+    assert len(data) > 0
 
     token_regexp = r"\b\w\w+\b"
 

--- a/benchmarks/bench_vectorizers.py
+++ b/benchmarks/bench_vectorizers.py
@@ -1,13 +1,15 @@
 from time import time
 from glob import glob
+from pathlib import Path
 
 import sklearn.feature_extraction.text as skt
 
 import pytext_vectorize
 
+base_dir = Path(__file__).parent.parent.resolve()
 
 if __name__ == "__main__":
-    input_files = list(glob("./data/*/*"))
+    input_files = list(glob(str(base_dir / "data" / "*" / "*")))
     data = []
     for file_path in input_files:
         with open(file_path, "rt") as fh:

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -158,7 +158,7 @@ impl UnicodeSegmentTokenizer {
         let x = x.to_string();
 
         let res = tokenizer.tokenize(&x);
-        let res = res.iter().map(|s| s.to_string()).collect();
+        let res = res.map(|s| s.to_string()).collect();
         Ok((res))
     }
 }
@@ -194,7 +194,7 @@ impl RegexpTokenizer {
     fn tokenize(&self, py: Python, x: String) -> PyResult<(Vec<String>)> {
         // TODO: reduce the number of copies here
         let res = self.inner.tokenize(&x);
-        let res: Vec<String> = res.iter().map(|s| s.to_string()).collect();
+        let res: Vec<String> = res.map(|s| s.to_string()).collect();
         Ok((res))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl CountVectorizer {
             let tokens = tokenizer.tokenize(&document);
 
             indices_local.clear();
-            for token in tokens.iter() {
+            for token in tokens {
                 let vocabulary_size = vocabulary.len() as i32;
                 // TODO: don't convert to Sting here
                 let token_id = vocabulary
@@ -238,7 +238,7 @@ impl HashingVectorizer {
 
             let tokens = tokenizer.tokenize(&document);
             indices_local.clear();
-            for token in tokens.iter() {
+            for token in tokens {
                 let hash = fasthash::murmur3::hash32(&token);
                 let hash = hash % self.n_features;
 


### PR DESCRIPTION
Return iterator in tokenizers which increases performance a bit.

Using the `bench_tokenizers.py` script,
*master*
```
# Tokenizing 19924 documents
         Python re.findall(r'\b\w\w+\b', ...): 2.66s [34.2 MB/s]
                RegexpTokenizer(r'\b\w\w+\b'): 2.12s [42.9 MB/s]
   UnicodeSegmentTokenizer(word_bounds=False): 3.37s [27.0 MB/s]
    UnicodeSegmentTokenizer(word_bounds=True): 4.04s [22.5 MB/s]
```

*this PR*
```
# Tokenizing 19924 documents
         Python re.findall(r'\b\w\w+\b', ...): 2.57s [35.4 MB/s]
                RegexpTokenizer(r'\b\w\w+\b'): 1.93s [47.0 MB/s]
   UnicodeSegmentTokenizer(word_bounds=False): 3.11s [29.3 MB/s]
    UnicodeSegmentTokenizer(word_bounds=True): 3.72s [24.5 MB/s]
```
